### PR TITLE
Deduplicate Renovate package updates

### DIFF
--- a/renovate.config.ts
+++ b/renovate.config.ts
@@ -32,13 +32,17 @@ type PostPackageTasks = Array<
 >;
 
 const bootstrapRule: PostUpgradeTaskRule = {
+  matchManagers: ['npm'],
   matchFileNames: [
     'packages/commons/package.json',
     'packages/stylelint-config/package.json',
     ...workspaces.map(({ location }) => join(location, 'package.json'))
   ],
   postUpgradeTasks: {
-    commands: ['yarn bootstrap'],
+    commands: [
+      'yarn dedupe {{#each (distinct (lookupArray upgrades "packageName"))}}{{{.}}} {{/each}}',
+      'yarn bootstrap'
+    ],
     fileFilters: ['**/yarn.lock'],
     executionMode: 'branch'
   }


### PR DESCRIPTION
## Summary

- deduplicate only npm packages updated on each Renovate branch
- support grouped dependency updates by collecting distinct package names
- retain the existing workspace bootstrap after lockfile normalization

## Rationale

Yarn intentionally preserves compatible existing lockfile resolutions. This can leave an upgraded direct dependency and a stale transitive resolution side by side, as happened with Playwright. A global `yarn dedupe` currently changes 48 unrelated resolutions and breaks the Commons build, so this applies deduplication only to packages in the active Renovate update.

## Validation

- `yarn install --immutable`
- `yarn bootstrap`
- generated Renovate configuration assertion
- Renovate template rendering for grouped Playwright updates
- `yarn turbo run //#lint --env-mode=strict --verbosity=0`
- `git diff --check`